### PR TITLE
Add ColorColumn to palette

### DIFF
--- a/lua/zenburn/palette.lua
+++ b/lua/zenburn/palette.lua
@@ -1,6 +1,7 @@
 return {
 	Boolean = { fg="#dca3a3", },
 	Character = { fg="#dca3a3", bold=true, },
+	ColorColumn = { bg="#353535", },
 	Comment = { fg="#7f9f7f", },
 	Conditional = { fg="#f0dfaf", bold=true, },
 	Constant = { fg="#dca3a3", bold=true, },


### PR DESCRIPTION
`ColorColumn` is the color applied to the column set by `vim.opt.colorcolumn` (which you usually set to indicate where the 80/100/120-character line width is).

Currently zenburn.nvim doesn't set it at all, so on my terminal it defaults to an ugly bright red that clashes terribly with Zenburn. I've arbitrarily set it here to the same color used in the line number gutter, and that looks nice to me, but it's fine with me if you want to change it to any other Zenburn-themed color. Just not the default, please 🤮