### PR TITLE
lsp semantic highlight support

### DIFF
--- a/lua/zenburn/highlights/lsp.lua
+++ b/lua/zenburn/highlights/lsp.lua
@@ -4,6 +4,23 @@ return {
 	LspReferenceRead = c.IncSearch,
 	LspReferenceWrite = c.IncSearch,
 	LspSignatureActiveParameter = { fg=c.Conditional.fg, bold=true },
+
+    -- ['@lsp.type.class'] = c.Type,
+    -- ['@lsp.type.comment'] = c.Comment,
+    -- ['@lsp.type.decorator'] = c.PreProc,
+    -- ['@lsp.type.enum'] = c.Type,
+    -- ['@lsp.type.enumMember'] = c.Constant,
+    -- ['@lsp.type.function'] = c.Function,
+    -- ['@lsp.type.interface'] = c.Type,
+    ['@lsp.type.macro'] = c.Macro,
+    -- ['@lsp.type.method'] = c.Include,
+    -- ['@lsp.type.namespace'] = c.Include,
+    ['@lsp.type.parameter'] = c.ModeMsg,
+    -- ['@lsp.type.property'] = c.Identifier,
+    -- ['@lsp.type.struct'] = c.Structure,
+    -- ['@lsp.type.type'] = c.Type,
+    -- ['@lsp.type.typeParameter'] = c.Type,
+    ['@lsp.type.variable'] = c.Normal,
 }
 
 


### PR DESCRIPTION
Hey there! Thanks for the great theme. I recently upgraded to NeoVim 0.10.0 which has support for semantic highlighting. I noticed that this theme didn't had support for it, so I threw together this commit, see the below image for the result. It's based off of the treesitter highlights but I commented most of them out to be more minimal with the implementation.

![image](https://github.com/phha/zenburn.nvim/assets/169429672/c8805f7a-0b4e-4d49-950e-90894e9afb24)

Let me know if this looks good or if some of the options should be tweaked!
